### PR TITLE
Testing core object types

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,0 +1,26 @@
+name: "Run tests"
+on:
+  push:
+    paths:
+      - "seqspec/*"
+      - "assays/*"
+      - "tests/*"
+      - "setup.py"
+      - "setup.cfg"
+      - ".github/workflows/ci-test.yml"
+
+jobs:
+  run-tests:
+    runs-on: "ubuntu-latest"
+    steps:
+      - run: echo "This job is now running on ${{ runner.os }}"
+      - run: echo "The repository is ${{ github.repository }} on branch ${{ github.ref }}"
+      - name: "Check out repository"
+        uses: actions/checkout@v2
+      - run: echo "Checkout successful"
+      - name: Run tests
+        run: |
+          python --version
+          pip install tox
+          tox
+      - run: echo "The job status was ${{ job.status }}"

--- a/assays/10x-ATAC/spec.yaml
+++ b/assays/10x-ATAC/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: ATAC
-    order: 0
   - !Region
     region_id: I2.fastq.gz
     region_type: fastq
@@ -39,7 +38,6 @@ assay_spec:
     max_len: 16
     onlist: null
     parent_id: ATAC
-    order: 1
     regions:
     - !Region
       region_id: cell_bc
@@ -54,7 +52,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I2.fastq.gz
-      order: 0
   - !Region
     region_id: nextera_read1
     region_type: nextera_read1
@@ -64,7 +61,6 @@ assay_spec:
     min_len: 33
     max_len: 33
     onlist: null
-    order: 2
     regions:
     - !Region
       region_id: s5
@@ -77,7 +73,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read1
-      order: 0
     - !Region
       region_id: ME1
       region_type: ME1
@@ -89,7 +84,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read1
-      order: 1
   - !Region
     region_id: R1.fastq.gz
     region_type: fastq
@@ -99,7 +93,6 @@ assay_spec:
     min_len: 1
     max_len: 98
     onlist: null
-    order: 3
     regions:
     - !Region
       region_id: gDNA-1
@@ -112,7 +105,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R1.fastq.gz
-      order: 0
   - !Region
     region_id: R2.fastq.gz
     region_type: fastq
@@ -122,7 +114,6 @@ assay_spec:
     min_len: 1
     max_len: 98
     onlist: null
-    order: 4
     regions:
     - !Region
       region_id: gDNA-2
@@ -135,7 +126,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R2.fastq.gz
-      order: 0
   - !Region
     region_id: nextera_read2
     region_type: nextera_read2
@@ -157,7 +147,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read2
-      order: 0
     - !Region
       region_id: s7
       region_type: s7
@@ -169,8 +158,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read2
-      order: 1
-    order: 5
   - !Region
     region_id: I1.fastq.gz
     region_type: gz
@@ -194,8 +181,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 0
-    order: 6
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -207,5 +192,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: ATAC
-    order: 7
-  order: 0

--- a/assays/10x-RNA-5prime/spec.yaml
+++ b/assays/10x-RNA-5prime/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: truseq_read1
     region_type: truseq_read1
@@ -40,7 +39,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: R1.fastq.gz
     region_type: fastq
@@ -67,7 +65,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: R1.fastq.gz
-      order: 0
     - !Region
       region_id: umi
       region_type: umi
@@ -79,8 +76,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R1.fastq.gz
-      order: 1
-    order: 2
   - !Region
     region_id: bead_TSO
     region_type: bead_TSO
@@ -92,7 +87,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: R2.fastq.gz
     region_type: fastq
@@ -103,7 +97,6 @@ assay_spec:
     max_len: 98
     onlist: null
     parent_id: RNA
-    order: 4
     regions:
     - !Region
       region_id: cDNA
@@ -116,7 +109,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R2.fastq.gz
-      order: 0
   - !Region
     region_id: truseq_read2
     region_type: truseq_read2
@@ -128,7 +120,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: I1.fastq.gz
     region_type: gz
@@ -152,8 +143,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 0
-    order: 6
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -165,5 +154,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
-  order: 0

--- a/assays/10x-RNA-ATAC/spec.yaml
+++ b/assays/10x-RNA-ATAC/spec.yaml
@@ -19,7 +19,6 @@ assay_spec:
   onlist: null
   regions:
   - !Region
-    order: 0
     region_id: illumina_p5
     region_type: illumina_p5
     name: Illumina P5
@@ -31,7 +30,6 @@ assay_spec:
     regions: null
     parent_id: RNA
   - !Region
-    order: 1
     region_id: truseq_read1
     region_type: truseq_read1
     name: Truseq Read 1
@@ -43,7 +41,6 @@ assay_spec:
     regions: null
     parent_id: RNA
   - !Region
-    order: 2
     region_id: R1.fastq.gz
     region_type: fastq
     name: Read 1 FASTQ
@@ -54,7 +51,6 @@ assay_spec:
     onlist: null
     regions:
     - !Region
-      order: 0
       region_id: barcode
       region_type: barcode
       name: Cell Barcode
@@ -68,7 +64,6 @@ assay_spec:
       regions: null
       parent_id: R1.fastq.gz
     - !Region
-      order: 1
       region_id: umi
       region_type: umi
       name: UMI
@@ -80,7 +75,6 @@ assay_spec:
       regions: null
       parent_id: R1.fastq.gz
   - !Region
-    order: 3
     region_id: R2.fastq.gz
     region_type: fastq
     name: Read 2 FASTQ
@@ -91,7 +85,6 @@ assay_spec:
     onlist: null
     regions:
     - !Region
-      order: 0
       region_id: cDNA
       region_type: cDNA
       name: cDNA
@@ -114,9 +107,7 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
-    order: 5
     region_id: I1.fastq.gz
     region_type: fastq
     name: Index Read 2
@@ -127,7 +118,6 @@ assay_spec:
     onlist: null
     regions:
     - !Region
-      order: 0
       region_id: index7
       region_type: index7
       name: Truseq Read 2
@@ -141,7 +131,6 @@ assay_spec:
       regions: null
       parent_id: I1.fastq.gz
   - !Region
-    order: 6
     region_id: illumina_p7
     region_type: illumina_p7
     name: Illumina P7
@@ -152,7 +141,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-  order: 0
 - !Region
   region_id: ATAC
   region_type: ATAC
@@ -174,7 +162,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: ATAC
-    order: 0
   - !Region
     region_id: I2.fastq.gz
     region_type: fastq
@@ -185,7 +172,6 @@ assay_spec:
     max_len: 16
     onlist: null
     parent_id: ATAC
-    order: 1
     regions:
     - !Region
       region_id: cell_bc
@@ -200,7 +186,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I2.fastq.gz
-      order: 0
   - !Region
     region_id: spacer
     region_type: spacer
@@ -210,7 +195,6 @@ assay_spec:
     min_len: 33
     max_len: 33
     onlist: null
-    order: 2
     regions: null
     parent_id: ATAC
   - !Region
@@ -222,7 +206,6 @@ assay_spec:
     min_len: 33
     max_len: 33
     onlist: null
-    order: 3
     regions:
     - !Region
       region_id: s5
@@ -235,7 +218,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read1
-      order: 0
     - !Region
       region_id: ME1
       region_type: ME1
@@ -247,7 +229,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read1
-      order: 1
   - !Region
     region_id: R1.fastq.gz
     region_type: fastq
@@ -257,7 +238,6 @@ assay_spec:
     min_len: 1
     max_len: 98
     onlist: null
-    order: 4
     regions:
     - !Region
       region_id: gDNA-1
@@ -270,7 +250,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R1.fastq.gz
-      order: 0
   - !Region
     region_id: R2.fastq.gz
     region_type: fastq
@@ -280,7 +259,6 @@ assay_spec:
     min_len: 1
     max_len: 98
     onlist: null
-    order: 5
     regions:
     - !Region
       region_id: gDNA-2
@@ -293,7 +271,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R2.fastq.gz
-      order: 0
   - !Region
     region_id: nextera_read2
     region_type: nextera_read2
@@ -315,7 +292,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read2
-      order: 0
     - !Region
       region_id: s7
       region_type: s7
@@ -327,8 +303,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read2
-      order: 1
-    order: 6
   - !Region
     region_id: I1.fastq.gz
     region_type: gz
@@ -352,8 +326,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 0
-    order: 7
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -365,5 +337,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: ATAC
-    order: 8
-  order: 0

--- a/assays/10x-RNA-v1/spec.yaml
+++ b/assays/10x-RNA-v1/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: I2.fastq.gz
     region_type: gz
@@ -52,8 +51,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I2.fastq.gz
-      order: 0
-    order: 1
   - !Region
     region_id: truseq_read1
     region_type: truseq_read1
@@ -65,7 +62,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: R1.fastq.gz
     region_type: gz
@@ -87,8 +83,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R1.fastq.gz
-      order: 0
-    order: 3
   - !Region
     region_id: R2.fastq.gz
     region_type: fastq
@@ -99,7 +93,6 @@ assay_spec:
     max_len: 10
     onlist: null
     parent_id: RNA
-    order: 4
     regions:
     - !Region
       region_id: umi
@@ -112,7 +105,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R2.fastq.gz
-      order: 0
   - !Region
     region_id: truseq_read2
     region_type: truseq_read2
@@ -124,7 +116,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: I1.fastq.gz
     region_type: fastq
@@ -135,7 +126,6 @@ assay_spec:
     max_len: 14
     onlist: null
     parent_id: RNA
-    order: 6
     regions:
     - !Region
       region_id: barcode
@@ -150,7 +140,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 0
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -162,5 +151,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
-  order: 0

--- a/assays/10x-RNA-v2/spec.yaml
+++ b/assays/10x-RNA-v2/spec.yaml
@@ -18,7 +18,6 @@ assay_spec:
   onlist: null
   regions:
   - !Region
-    order: 0
     region_id: illumina_p5
     region_type: illumina_p5
     name: Illumina P5
@@ -30,7 +29,6 @@ assay_spec:
     regions: null
     parent_id: RNA
   - !Region
-    order: 1
     region_id: truseq_read1
     region_type: truseq_read1
     name: Truseq Read 1
@@ -42,7 +40,6 @@ assay_spec:
     regions: null
     parent_id: RNA
   - !Region
-    order: 2
     region_id: R1.fastq.gz
     region_type: fastq
     name: Read 1 FASTQ
@@ -53,7 +50,6 @@ assay_spec:
     onlist: null
     regions:
     - !Region
-      order: 0
       region_id: barcode
       region_type: barcode
       name: Cell Barcode
@@ -67,7 +63,6 @@ assay_spec:
       regions: null
       parent_id: R1.fastq.gz
     - !Region
-      order: 1
       region_id: umi
       region_type: umi
       name: UMI
@@ -79,7 +74,6 @@ assay_spec:
       regions: null
       parent_id: R1.fastq.gz
   - !Region
-    order: 3
     region_id: R2.fastq.gz
     region_type: fastq
     name: Read 2 FASTQ
@@ -90,7 +84,6 @@ assay_spec:
     onlist: null
     regions:
     - !Region
-      order: 0
       region_id: cDNA
       region_type: cDNA
       name: cDNA
@@ -113,9 +106,7 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
-    order: 5
     region_id: I1.fastq.gz
     region_type: fastq
     name: Index Read 2
@@ -126,7 +117,6 @@ assay_spec:
     onlist: null
     regions:
     - !Region
-      order: 0
       region_id: index7
       region_type: index7
       name: Truseq Read 2
@@ -140,7 +130,6 @@ assay_spec:
       regions: null
       parent_id: I1.fastq.gz
   - !Region
-    order: 6
     region_id: illumina_p7
     region_type: illumina_p7
     name: Illumina P7
@@ -151,4 +140,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-  order: 0

--- a/assays/10x-RNA-v3/spec.yaml
+++ b/assays/10x-RNA-v3/spec.yaml
@@ -18,7 +18,6 @@ assay_spec:
   onlist: null
   regions:
   - !Region
-    order: 0
     region_id: illumina_p5
     region_type: illumina_p5
     name: Illumina P5
@@ -30,7 +29,6 @@ assay_spec:
     regions: null
     parent_id: RNA
   - !Region
-    order: 1
     region_id: truseq_read1
     region_type: truseq_read1
     name: Truseq Read 1
@@ -42,7 +40,6 @@ assay_spec:
     regions: null
     parent_id: RNA
   - !Region
-    order: 2
     region_id: R1.fastq.gz
     region_type: fastq
     name: Read 1 FASTQ
@@ -53,7 +50,6 @@ assay_spec:
     onlist: null
     regions:
     - !Region
-      order: 0
       region_id: barcode
       region_type: barcode
       name: Cell Barcode
@@ -67,7 +63,6 @@ assay_spec:
       regions: null
       parent_id: R1.fastq.gz
     - !Region
-      order: 1
       region_id: umi
       region_type: umi
       name: UMI
@@ -79,7 +74,6 @@ assay_spec:
       regions: null
       parent_id: R1.fastq.gz
   - !Region
-    order: 3
     region_id: R2.fastq.gz
     region_type: fastq
     name: Read 2 FASTQ
@@ -90,7 +84,6 @@ assay_spec:
     onlist: null
     regions:
     - !Region
-      order: 0
       region_id: cDNA
       region_type: cDNA
       name: cDNA
@@ -113,9 +106,7 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
-    order: 5
     region_id: I1.fastq.gz
     region_type: fastq
     name: Index Read 2
@@ -126,7 +117,6 @@ assay_spec:
     onlist: null
     regions:
     - !Region
-      order: 0
       region_id: index7
       region_type: index7
       name: Truseq Read 2
@@ -140,7 +130,6 @@ assay_spec:
       regions: null
       parent_id: I1.fastq.gz
   - !Region
-    order: 6
     region_id: illumina_p7
     region_type: illumina_p7
     name: Illumina P7
@@ -151,4 +140,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-  order: 0

--- a/assays/10xCRISPR/spec.yaml
+++ b/assays/10xCRISPR/spec.yaml
@@ -29,7 +29,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: CRISPR
-    order: 0
   - !Region
     region_id: nextera_r1
     region_type: nextera_r1
@@ -41,7 +40,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: CRISPR
-    order: 1
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -55,7 +53,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: CRISPR
-    order: 2
   - !Region
     region_id: umi
     region_type: umi
@@ -67,7 +64,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: CRISPR
-    order: 3
   - !Region
     region_id: cap_seq_1
     region_type: cap_seq_1
@@ -79,7 +75,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: CRISPR
-    order: 4
   - !Region
     region_id: sgRNA_scaffold
     region_type: sgRNA_scaffold
@@ -91,7 +86,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: CRISPR
-    order: 5
   - !Region
     region_id: sgRNA_target
     region_type: sgRNA_target
@@ -105,7 +99,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: CRISPR
-    order: 6
   - !Region
     region_id: triple_c
     region_type: triple_c
@@ -117,7 +110,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: CRISPR
-    order: 7
   - !Region
     region_id: tso
     region_type: tso
@@ -129,7 +121,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: CRISPR
-    order: 8
   - !Region
     region_id: truseq_r2
     region_type: truseq_r2
@@ -141,7 +132,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: CRISPR
-    order: 9
   - !Region
     region_id: sample_index
     region_type: sample_index
@@ -153,7 +143,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: CRISPR
-    order: 10
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -165,8 +154,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: CRISPR
-    order: 11
-  order: 0
 - !Region
   region_id: RNA
   region_type: RNA
@@ -188,7 +175,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: truseq_r1
     region_type: truseq_r1
@@ -200,7 +186,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -214,7 +199,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: umi
     region_type: umi
@@ -226,7 +210,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: poly_T
     region_type: poly_T
@@ -238,7 +221,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: cDNA
     region_type: cDNA
@@ -250,7 +232,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: truseq_r2
     region_type: truseq_r2
@@ -262,7 +243,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: sample_bc
     region_type: sample_bc
@@ -276,7 +256,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -288,5 +267,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
-  order: 0

--- a/assays/10xFB-3prime/spec.yaml
+++ b/assays/10xFB-3prime/spec.yaml
@@ -29,7 +29,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: truseq_r1
     region_type: truseq_r1
@@ -41,7 +40,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -55,7 +53,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: umi
     region_type: umi
@@ -67,7 +64,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: poly_T
     region_type: poly_T
@@ -79,7 +75,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: cDNA
     region_type: cDNA
@@ -91,7 +86,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: truseq_r2
     region_type: truseq_r2
@@ -103,7 +97,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: sample_bc
     region_type: sample_bc
@@ -117,7 +110,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -129,8 +121,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
-  order: 0
 - !Region
   region_id: Protein
   region_type: Protein
@@ -152,7 +142,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 0
   - !Region
     region_id: nextera_read1
     region_type: nextera_read1
@@ -164,7 +153,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 1
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -178,7 +166,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: Protein
-    order: 2
   - !Region
     region_id: umi
     region_type: umi
@@ -190,7 +177,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 3
   - !Region
     region_id: capture_seq
     region_type: capture_seq
@@ -202,7 +188,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 4
   - !Region
     region_id: random_9mer1
     region_type: random_9mer1
@@ -214,7 +199,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 5
   - !Region
     region_id: feature_barcode
     region_type: feature_barcode
@@ -228,7 +212,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: Protein
-    order: 6
   - !Region
     region_id: random_9mer2
     region_type: random_9mer2
@@ -240,7 +223,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 7
   - !Region
     region_id: truseq_r2
     region_type: truseq_r2
@@ -252,7 +234,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 8
   - !Region
     region_id: sample_bc
     region_type: sample_bc
@@ -266,7 +247,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: Protein
-    order: 9
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -278,5 +258,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 10
-  order: 0

--- a/assays/10xFB-5prime/spec.yaml
+++ b/assays/10xFB-5prime/spec.yaml
@@ -29,7 +29,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: i5_index
     region_type: i5_index
@@ -43,7 +42,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: truseq_r1
     region_type: truseq_r1
@@ -55,7 +53,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -69,7 +66,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: umi
     region_type: umi
@@ -81,7 +77,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: bead_TSO
     region_type: bead_TSO
@@ -93,7 +88,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: cDNA
     region_type: cDNA
@@ -105,7 +99,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: truseq_r2
     region_type: truseq_r2
@@ -117,7 +110,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: sample_bc
     region_type: sample_bc
@@ -131,7 +123,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -143,8 +134,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 9
-  order: 0
 - !Region
   region_id: Protein
   region_type: Protein
@@ -166,7 +155,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 0
   - !Region
     region_id: i5_index
     region_type: i5_index
@@ -180,7 +168,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: Protein
-    order: 1
   - !Region
     region_id: truseq_read1
     region_type: truseq_read1
@@ -192,7 +179,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 2
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -206,7 +192,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: Protein
-    order: 3
   - !Region
     region_id: umi
     region_type: umi
@@ -218,7 +203,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 4
   - !Region
     region_id: bead_TSO
     region_type: bead_TSO
@@ -230,7 +214,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 5
   - !Region
     region_id: spacer1
     region_type: spacer1
@@ -242,7 +225,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 6
   - !Region
     region_id: feature_bc
     region_type: feature_bc
@@ -256,7 +238,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: Protein
-    order: 7
   - !Region
     region_id: spacer2
     region_type: spacer2
@@ -268,7 +249,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 8
   - !Region
     region_id: nextera_read2
     region_type: nextera_read2
@@ -280,7 +260,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 9
   - !Region
     region_id: sample_index
     region_type: sample_index
@@ -294,7 +273,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: Protein
-    order: 10
   - !Region
     region_id: illlumina_p7
     region_type: illlumina_p7
@@ -306,5 +284,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: Protein
-    order: 11
-  order: 0

--- a/assays/10xFB-VDJ-5prime/spec.yaml
+++ b/assays/10xFB-VDJ-5prime/spec.yaml
@@ -29,7 +29,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: i5_index
     region_type: i5_index
@@ -43,7 +42,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: truseq_r1
     region_type: truseq_r1
@@ -55,7 +53,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -69,7 +66,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: umi
     region_type: umi
@@ -81,7 +77,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: bead_TSO
     region_type: bead_TSO
@@ -93,7 +88,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: cDNA
     region_type: cDNA
@@ -105,7 +99,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: truseq_r2
     region_type: truseq_r2
@@ -117,7 +110,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: sample_bc
     region_type: sample_bc
@@ -131,7 +123,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -143,8 +134,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 9
-  order: 0
 - !Region
   region_id: VDJ
   region_type: VDJ
@@ -166,7 +155,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: VDJ
-    order: 0
   - !Region
     region_id: i5_index
     region_type: i5_index
@@ -180,7 +168,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: VDJ
-    order: 1
   - !Region
     region_id: truseq_read1
     region_type: truseq_read1
@@ -192,7 +179,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: VDJ
-    order: 2
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -206,7 +192,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: VDJ
-    order: 3
   - !Region
     region_id: umi
     region_type: umi
@@ -218,7 +203,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: VDJ
-    order: 4
   - !Region
     region_id: bead_TSO
     region_type: bead_TSO
@@ -230,7 +214,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: VDJ
-    order: 5
   - !Region
     region_id: vdj
     region_type: vdj
@@ -242,7 +225,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: VDJ
-    order: 6
   - !Region
     region_id: truseq_read2
     region_type: truseq_read2
@@ -254,7 +236,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: VDJ
-    order: 7
   - !Region
     region_id: sample_index
     region_type: sample_index
@@ -268,7 +249,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: VDJ
-    order: 8
   - !Region
     region_id: illlumina_p7
     region_type: illlumina_p7
@@ -280,5 +260,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: VDJ
-    order: 9
-  order: 0

--- a/assays/BD-Rhapsody-EB/spec.yaml
+++ b/assays/BD-Rhapsody-EB/spec.yaml
@@ -29,7 +29,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: truseq_r1
     region_type: truseq_r1
@@ -41,7 +40,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: vb
     region_type: vb
@@ -55,7 +53,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: cls1
     region_type: cls1
@@ -69,7 +66,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: linker1
     region_type: linker1
@@ -81,7 +77,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: cls2
     region_type: cls2
@@ -95,7 +90,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: linker2
     region_type: linker2
@@ -107,7 +101,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: cls3
     region_type: cls3
@@ -121,7 +114,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: umi
     region_type: umi
@@ -133,7 +125,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: polyT
     region_type: polyT
@@ -145,7 +136,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 9
   - !Region
     region_id: cdna
     region_type: cdna
@@ -157,7 +147,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 10
   - !Region
     region_id: truseq_r2
     region_type: truseq_r2
@@ -169,7 +158,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 11
   - !Region
     region_id: sample_index
     region_type: sample_index
@@ -183,7 +171,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 12
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -195,5 +182,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 13
-  order: 0

--- a/assays/BD-Rhapsody-v1/spec.yaml
+++ b/assays/BD-Rhapsody-v1/spec.yaml
@@ -29,7 +29,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: truseq_r1
     region_type: truseq_r1
@@ -41,7 +40,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: cls1
     region_type: cls1
@@ -55,7 +53,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: linker1
     region_type: linker1
@@ -67,7 +64,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: cls2
     region_type: cls2
@@ -81,7 +77,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: linker2
     region_type: linker2
@@ -93,7 +88,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: cls3
     region_type: cls3
@@ -107,7 +101,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: umi
     region_type: umi
@@ -119,7 +112,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: polyT
     region_type: polyT
@@ -131,7 +123,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: cdna
     region_type: cdna
@@ -143,7 +134,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 9
   - !Region
     region_id: truseq_r2
     region_type: truseq_r2
@@ -155,7 +145,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 10
   - !Region
     region_id: sample_index
     region_type: sample_index
@@ -169,7 +158,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 11
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -181,5 +169,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 12
-  order: 0

--- a/assays/CEL-Seq/spec.yaml
+++ b/assays/CEL-Seq/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: RA5
     region_type: RA5
@@ -40,7 +39,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -52,7 +50,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: poly_T
     region_type: poly_T
@@ -64,7 +61,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: cDNA
     region_type: cDNA
@@ -76,7 +72,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: RA3
     region_type: RA3
@@ -88,7 +83,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: link_1
     region_type: link_1
@@ -100,7 +94,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: sample_bc
     region_type: sample_bc
@@ -114,7 +107,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -126,5 +118,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
-  order: 0

--- a/assays/CEL-Seq2/spec.yaml
+++ b/assays/CEL-Seq2/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: RA5
     region_type: RA5
@@ -40,7 +39,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: umi
     region_type: umi
@@ -52,7 +50,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -64,7 +61,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: poly_T
     region_type: poly_T
@@ -76,7 +72,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: cDNA
     region_type: cDNA
@@ -88,7 +83,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: RA3
     region_type: RA3
@@ -100,7 +94,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: link_1
     region_type: link_1
@@ -112,7 +105,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: sample_bc
     region_type: sample_bc
@@ -126,7 +118,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -138,5 +129,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 9
-  order: 0

--- a/assays/Drop-seq/spec.yaml
+++ b/assays/Drop-seq/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: r1_primer
     region_type: r1_primer
@@ -40,7 +39,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -54,7 +52,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: umi
     region_type: umi
@@ -66,7 +63,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: polyT
     region_type: polyT
@@ -78,7 +74,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: cdna
     region_type: cdna
@@ -90,7 +85,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: ME
     region_type: ME
@@ -102,7 +96,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: s7
     region_type: s7
@@ -114,7 +107,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: i7_index
     region_type: i7_index
@@ -128,7 +120,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -140,5 +131,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 9
-  order: 0

--- a/assays/Illumina/nextera_dual_index.yaml
+++ b/assays/Illumina/nextera_dual_index.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: template
-    order: 0
   - !Region
     region_id: I2.fastq.gz
     region_type: gz
@@ -52,8 +51,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I2.fastq.gz
-      order: 0
-    order: 1
   - !Region
     region_id: nextera_read1
     region_type: nextera_read1
@@ -75,7 +72,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read1
-      order: 0
     - !Region
       region_id: ME1
       region_type: ME1
@@ -87,8 +83,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read1
-      order: 1
-    order: 2
   - !Region
     region_id: R1.fastq.gz
     region_type: gz
@@ -110,8 +104,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R1.fastq.gz
-      order: 0
-    order: 3
   - !Region
     region_id: nextera_read2
     region_type: nextera_read2
@@ -133,7 +125,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read2
-      order: 0
     - !Region
       region_id: s7
       region_type: s7
@@ -145,8 +136,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read2
-      order: 1
-    order: 4
   - !Region
     region_id: I1.fastq.gz
     region_type: gz
@@ -170,8 +159,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 0
-    order: 5
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -183,5 +170,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: template
-    order: 6
-  order: 0

--- a/assays/Illumina/truseq_dual_index.yaml
+++ b/assays/Illumina/truseq_dual_index.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: template
-    order: 0
   - !Region
     region_id: I2.fastq.gz
     region_type: gz
@@ -52,7 +51,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I2.fastq.gz
-      order: 0
   - !Region
     region_id: truseq_read1
     region_type: truseq_read1
@@ -64,7 +62,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: I2.fastq.gz
-    order: 1
   - !Region
     region_id: R1.fastq.gz
     region_type: gz
@@ -86,8 +83,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R1.fastq.gz
-      order: 0
-    order: 2
   - !Region
     region_id: R2.fastq.gz
     region_type: gz
@@ -109,8 +104,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R2.fastq.gz
-      order: 0
-    order: 3
   - !Region
     region_id: truseq_read2
     region_type: truseq_read2
@@ -122,7 +115,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: I2.fastq.gz
-    order: 4
   - !Region
     region_id: I1.fastq.gz
     region_type: gz
@@ -146,8 +138,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 0
-    order: 5
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -159,6 +149,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: I2.fastq.gz
-    order: 6
-  order: 1
-order: 0

--- a/assays/Illumina/truseq_single_index.yaml
+++ b/assays/Illumina/truseq_single_index.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: template
-    order: 0
   - !Region
     region_id: truseq_read1
     region_type: truseq_read1
@@ -40,7 +39,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: template
-    order: 1
   - !Region
     region_id: R1.fastq.gz
     region_type: gz
@@ -62,8 +60,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R1.fastq.gz
-      order: 0
-    order: 2
   - !Region
     region_id: R2.fastq.gz
     region_type: gz
@@ -85,8 +81,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R2.fastq.gz
-      order: 0
-    order: 3
   - !Region
     region_id: truseq_read2
     region_type: truseq_read2
@@ -98,7 +92,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: template
-    order: 4
   - !Region
     region_id: I1.fastq.gz
     region_type: gz
@@ -122,8 +115,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 0
-    order: 5
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -135,5 +126,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: template
-    order: 6
-  order: 0

--- a/assays/MARS-seq/spec.yaml
+++ b/assays/MARS-seq/spec.yaml
@@ -29,7 +29,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: truseq_r1
     region_type: truseq_r1
@@ -41,7 +40,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: plate_bc
     region_type: plate_bc
@@ -55,7 +53,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: cdna
     region_type: cdna
@@ -67,7 +64,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: polyA
     region_type: polyA
@@ -79,7 +75,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: umi
     region_type: umi
@@ -91,7 +86,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -105,7 +99,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: truseq_r2
     region_type: truseq_r2
@@ -117,7 +110,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -129,5 +121,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
-  order: 0

--- a/assays/Microwell-seq/spec.yaml
+++ b/assays/Microwell-seq/spec.yaml
@@ -29,7 +29,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: read_1_primer
     region_type: read_1_primer
@@ -41,7 +40,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: bc1
     region_type: bc1
@@ -55,7 +53,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: linker1
     region_type: linker1
@@ -67,7 +64,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: bc2
     region_type: bc2
@@ -81,7 +77,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: linker2
     region_type: linker2
@@ -93,7 +88,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: bc3
     region_type: bc3
@@ -107,7 +101,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: umi
     region_type: umi
@@ -119,7 +112,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: polyT
     region_type: polyT
@@ -131,7 +123,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: cdna
     region_type: cdna
@@ -143,7 +134,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 9
   - !Region
     region_id: ME
     region_type: ME
@@ -155,7 +145,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 10
   - !Region
     region_id: s7
     region_type: s7
@@ -167,7 +156,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 11
   - !Region
     region_id: sample_index
     region_type: sample_index
@@ -181,7 +169,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 12
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -193,5 +180,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 13
-  order: 0

--- a/assays/Pi-ATAC-seq/spec.yaml
+++ b/assays/Pi-ATAC-seq/spec.yaml
@@ -29,7 +29,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: ATAC
-    order: 0
   - !Region
     region_id: i5
     region_type: i5
@@ -43,7 +42,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: ATAC
-    order: 1
   - !Region
     region_id: nextera_read1
     region_type: nextera_read1
@@ -65,7 +63,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read1
-      order: 0
     - !Region
       region_id: ME
       region_type: ME
@@ -77,8 +74,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read1
-      order: 1
-    order: 2
   - !Region
     region_id: gdna
     region_type: gdna
@@ -90,7 +85,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: ATAC
-    order: 3
   - !Region
     region_id: nextera_read2
     region_type: nextera_read2
@@ -112,7 +106,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read2
-      order: 0
     - !Region
       region_id: s5
       region_type: s5
@@ -124,8 +117,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read2
-      order: 1
-    order: 4
   - !Region
     region_id: i7
     region_type: i7
@@ -139,7 +130,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: ATAC
-    order: 5
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -151,5 +141,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: ATAC
-    order: 6
-  order: 0

--- a/assays/Quartz-seq/spec.yaml
+++ b/assays/Quartz-seq/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: truseq_read_1
     region_type: truseq_read_1
@@ -40,7 +39,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: cDNA
     region_type: cDNA
@@ -52,7 +50,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: truseq_read_2
     region_type: truseq_read_2
@@ -64,7 +61,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: cell_index
     region_type: cell_index
@@ -76,7 +72,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -88,5 +83,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
-  order: 0

--- a/assays/Quartz-seq2/spec.yaml
+++ b/assays/Quartz-seq2/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: double_T
     region_type: double_T
@@ -40,7 +39,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: gM_primer
     region_type: gM_primer
@@ -52,7 +50,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: link_1
     region_type: link_1
@@ -64,7 +61,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -78,7 +74,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: umi
     region_type: umi
@@ -90,7 +85,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: ploy_T
     region_type: ploy_T
@@ -102,7 +96,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: cDNA
     region_type: cDNA
@@ -114,7 +107,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: truseq_read_2
     region_type: truseq_read_2
@@ -126,7 +118,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: sample_index
     region_type: sample_index
@@ -138,7 +129,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 9
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -150,5 +140,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 10
-  order: 0

--- a/assays/SHARE-seq/spec.yaml
+++ b/assays/SHARE-seq/spec.yaml
@@ -30,7 +30,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: I2.fastq.gz
     region_type: gz
@@ -54,8 +53,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I2.fastq.gz
-      order: 0
-    order: 1
   - !Region
     region_id: nextera_read1
     region_type: nextera_read1
@@ -77,7 +74,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read1
-      order: 0
     - !Region
       region_id: ME1
       region_type: ME1
@@ -89,8 +85,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read1
-      order: 1
-    order: 2
   - !Region
     region_id: R1.fastq.gz
     region_type: gz
@@ -112,8 +106,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R1.fastq.gz
-      order: 0
-    order: 3
   - !Region
     region_id: R2.fastq.gz
     region_type: gz
@@ -135,7 +127,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R2.fastq.gz
-      order: 0
     - !Region
       region_id: UMI
       region_type: UMI
@@ -147,8 +138,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R2.fastq.gz
-      order: 1
-    order: 4
   - !Region
     region_id: nextera_read2
     region_type: nextera_read2
@@ -170,7 +159,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read2
-      order: 0
     - !Region
       region_id: s7
       region_type: s7
@@ -182,8 +170,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read2
-      order: 1
-    order: 5
   - !Region
     region_id: I1.fastq.gz
     region_type: gz
@@ -205,7 +191,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 0
     - !Region
       region_id: bc1
       region_type: bc1
@@ -219,7 +204,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 1
     - !Region
       region_id: linker2
       region_type: linker2
@@ -231,7 +215,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 2
     - !Region
       region_id: bc2
       region_type: bc2
@@ -245,7 +228,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 3
     - !Region
       region_id: linker3
       region_type: linker3
@@ -257,7 +239,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 4
     - !Region
       region_id: bc3
       region_type: bc3
@@ -271,8 +252,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 5
-    order: 6
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -286,8 +265,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 7
-  order: 0
 - !Region
   region_id: ATAC
   region_type: ATAC
@@ -309,7 +286,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: ATAC
-    order: 0
   - !Region
     region_id: I2.fastq.gz
     region_type: gz
@@ -333,8 +309,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I2.fastq.gz
-      order: 0
-    order: 1
   - !Region
     region_id: nextera_read1
     region_type: nextera_read1
@@ -356,7 +330,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read1
-      order: 0
     - !Region
       region_id: ME1
       region_type: ME1
@@ -368,8 +341,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read1
-      order: 1
-    order: 2
   - !Region
     region_id: R1.fastq.gz
     region_type: gz
@@ -391,8 +362,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R1.fastq.gz
-      order: 0
-    order: 3
   - !Region
     region_id: R2.fastq.gz
     region_type: gz
@@ -414,8 +383,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R2.fastq.gz
-      order: 0
-    order: 4
   - !Region
     region_id: nextera_read2
     region_type: nextera_read2
@@ -437,7 +404,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read2
-      order: 0
     - !Region
       region_id: s7
       region_type: s7
@@ -449,8 +415,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read2
-      order: 1
-    order: 5
   - !Region
     region_id: I1.fastq.gz
     region_type: gz
@@ -472,7 +436,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 0
     - !Region
       region_id: bc1
       region_type: bc1
@@ -486,7 +449,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 1
     - !Region
       region_id: linker2
       region_type: linker2
@@ -498,7 +460,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 2
     - !Region
       region_id: bc2
       region_type: bc2
@@ -512,7 +473,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 3
     - !Region
       region_id: linker3
       region_type: linker3
@@ -524,7 +484,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 4
     - !Region
       region_id: bc3
       region_type: bc3
@@ -538,8 +497,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 5
-    order: 6
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -553,5 +510,3 @@ assay_spec:
       md5: null
     regions: null
     parent_id: ATAC
-    order: 7
-  order: 0

--- a/assays/SPLiT-seq/spec.yaml
+++ b/assays/SPLiT-seq/spec.yaml
@@ -8,7 +8,6 @@ modalities:
 lib_struct: https://teichlab.github.io/scg_lib_structs/methods_html/SPLiT-seq.html
 assay_spec:
 - !Region
-  order: 0
   region_id: RNA
   region_type: RNA
   name: RNA
@@ -19,7 +18,6 @@ assay_spec:
   onlist: null
   regions:
   - !Region
-    order: 0
     region_id: illumina_p5
     region_type: illumina_p5
     name: illumina_p5
@@ -31,7 +29,6 @@ assay_spec:
     regions: null
     parent_id: RNA
   - !Region
-    order: 1
     region_id: nextera_read1
     region_type: nextera_read1
     name: nextera_read1
@@ -42,7 +39,6 @@ assay_spec:
     onlist: null
     regions:
     - !Region
-      order: 0
       region_id: s5
       region_type: s5
       name: s5
@@ -54,7 +50,6 @@ assay_spec:
       regions: null
       parent_id: nextera_read1
     - !Region
-      order: 1
       region_id: ME1
       region_type: ME1
       name: ME1
@@ -66,7 +61,6 @@ assay_spec:
       regions: null
       parent_id: nextera_read1
   - !Region
-    order: 2
     region_id: R1.fastq.gz
     region_type: fastq
     name: R1.fastq.gz
@@ -77,7 +71,6 @@ assay_spec:
     onlist: null
     regions:
     - !Region
-      order: 0
       region_id: cDNA
       region_type: cDNA
       name: cDNA
@@ -89,7 +82,6 @@ assay_spec:
       regions: null
       parent_id: R1.fastq.gz
   - !Region
-    order: 3
     region_id: R2.fastq.gz
     region_type: fastq
     name: Read 2 FASTQ
@@ -100,7 +92,6 @@ assay_spec:
     onlist: null
     regions:
     - !Region
-      order: 0
       region_id: barcode-1
       region_type: barcode
       name: barcode-1
@@ -114,7 +105,6 @@ assay_spec:
       regions: null
       parent_id: R2.fastq.gz
     - !Region
-      order: 1
       region_id: linker-2
       region_type: linker
       name: linker-2
@@ -126,7 +116,6 @@ assay_spec:
       regions: null
       parent_id: R2.fastq.gz
     - !Region
-      order: 2
       region_id: barcode-2
       region_type: barcode
       name: barcode-2
@@ -140,7 +129,6 @@ assay_spec:
       regions: null
       parent_id: R2.fastq.gz
     - !Region
-      order: 3
       region_id: linker-3
       region_type: linker
       name: linker-3
@@ -152,7 +140,6 @@ assay_spec:
       regions: null
       parent_id: R2.fastq.gz
     - !Region
-      order: 4
       region_id: barcode-3
       region_type: barcode
       name: barcode-3
@@ -166,7 +153,6 @@ assay_spec:
       regions: null
       parent_id: R2.fastq.gz
     - !Region
-      order: 5
       region_id: umi
       region_type: umi
       name: umi
@@ -178,7 +164,6 @@ assay_spec:
       regions: null
       parent_id: R2.fastq.gz
   - !Region
-    order: 4
     region_id: truseq_read2
     region_type: truseq_read2
     name: truseq_read2
@@ -190,7 +175,6 @@ assay_spec:
     regions: null
     parent_id: RNA
   - !Region
-    order: 5
     region_id: I1.fastq.gz
     region_type: fastq
     name: Index 1 FASTQ
@@ -201,7 +185,6 @@ assay_spec:
     onlist: null
     regions:
     - !Region
-      order: 0
       region_id: index7
       region_type: index7
       name: index7
@@ -215,7 +198,6 @@ assay_spec:
       regions: null
       parent_id: I1.fastq.gz
   - !Region
-    order: 6
     region_id: illumina_p7
     region_type: illumina_p7
     name: illumina_p7

--- a/assays/STRT-seq-2i/spec.yaml
+++ b/assays/STRT-seq-2i/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: link_1
     region_type: link_1
@@ -40,7 +39,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: well_bc
     region_type: well_bc
@@ -52,7 +50,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: link_2
     region_type: link_2
@@ -64,7 +61,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: umi
     region_type: umi
@@ -76,7 +72,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: triple_G
     region_type: triple_G
@@ -88,7 +83,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: cDNA
     region_type: cDNA
@@ -100,7 +94,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: ME
     region_type: ME
@@ -112,7 +105,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: link_3
     region_type: link_3
@@ -124,7 +116,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: subarray_bc
     region_type: subarray_bc
@@ -136,7 +127,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 9
   - !Region
     region_id: solexa_p2
     region_type: solexa_p2
@@ -148,5 +138,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 10
-  order: 0

--- a/assays/STRT-seq-C1/spec.yaml
+++ b/assays/STRT-seq-C1/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: link_1
     region_type: link_1
@@ -40,7 +39,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: umi
     region_type: umi
@@ -52,7 +50,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: triple_G
     region_type: triple_G
@@ -64,7 +61,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: cDNA
     region_type: cDNA
@@ -76,7 +72,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: ME
     region_type: ME
@@ -88,7 +83,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: link_2
     region_type: link_2
@@ -100,7 +94,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -112,7 +105,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: solexa_p2
     region_type: solexa_p2
@@ -124,5 +116,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
-  order: 0

--- a/assays/STRT-seq/spec.yaml
+++ b/assays/STRT-seq/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: link_1
     region_type: link_1
@@ -40,7 +39,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: ispcr
     region_type: ispcr
@@ -52,7 +50,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: link_2
     region_type: link_2
@@ -64,7 +61,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -76,7 +72,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: triple_G
     region_type: triple_G
@@ -88,7 +83,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: cDNA
     region_type: cDNA
@@ -100,7 +94,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: link_3
     region_type: link_3
@@ -112,7 +105,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: solexa_p2
     region_type: solexa_p2
@@ -124,5 +116,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
-  order: 0

--- a/assays/Seq-well-S3/spec.yaml
+++ b/assays/Seq-well-S3/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: tso
     region_type: tso
@@ -40,7 +39,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -54,7 +52,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: umi
     region_type: umi
@@ -66,7 +63,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: polyT
     region_type: polyT
@@ -78,7 +74,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: cdna
     region_type: cdna
@@ -90,7 +85,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: ME
     region_type: ME
@@ -102,7 +96,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: s7
     region_type: s7
@@ -114,7 +107,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: i7_index
     region_type: i7_index
@@ -128,7 +120,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -140,5 +131,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 9
-  order: 0

--- a/assays/Seq-well/spec.yaml
+++ b/assays/Seq-well/spec.yaml
@@ -30,7 +30,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: r1_primer
     region_type: r1_primer
@@ -42,7 +41,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -56,7 +54,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: umi
     region_type: umi
@@ -68,7 +65,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: polyT
     region_type: polyT
@@ -80,7 +76,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: cdna
     region_type: cdna
@@ -92,7 +87,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: ME
     region_type: ME
@@ -104,7 +98,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: s7
     region_type: s7
@@ -116,7 +109,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: i7_index
     region_type: i7_index
@@ -130,7 +122,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -142,5 +133,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 9
-  order: 0

--- a/assays/Smart-seq2/spec.yaml
+++ b/assays/Smart-seq2/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: i5
     region_type: i5
@@ -42,7 +41,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: s5
     region_type: s5
@@ -54,7 +52,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: ME1
     region_type: ME1
@@ -66,7 +63,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: cDNA
     region_type: cDNA
@@ -78,7 +74,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: ME2
     region_type: ME2
@@ -90,7 +85,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: s7
     region_type: s7
@@ -102,7 +96,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: i7
     region_type: i7
@@ -116,7 +109,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -128,5 +120,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
-  order: 0

--- a/assays/Smart-seq3/spec.yaml
+++ b/assays/Smart-seq3/spec.yaml
@@ -29,7 +29,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_end
-    order: 0
   - !Region
     region_id: i5
     region_type: i5
@@ -43,7 +42,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA_end
-    order: 1
   - !Region
     region_id: s5
     region_type: s5
@@ -55,7 +53,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_end
-    order: 2
   - !Region
     region_id: ME1
     region_type: ME1
@@ -67,7 +64,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_end
-    order: 3
   - !Region
     region_id: five_prime_fragment_tag
     region_type: five_prime_fragment_tag
@@ -79,7 +75,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_end
-    order: 4
   - !Region
     region_id: umi
     region_type: umi
@@ -91,7 +86,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_end
-    order: 5
   - !Region
     region_id: triple_G
     region_type: triple_G
@@ -103,7 +97,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_end
-    order: 6
   - !Region
     region_id: cDNA
     region_type: cDNA
@@ -115,7 +108,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_end
-    order: 7
   - !Region
     region_id: ME2
     region_type: ME2
@@ -127,7 +119,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_end
-    order: 8
   - !Region
     region_id: s7
     region_type: s7
@@ -139,7 +130,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_end
-    order: 9
   - !Region
     region_id: i7
     region_type: i7
@@ -153,7 +143,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA_end
-    order: 10
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -165,8 +154,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_end
-    order: 11
-  order: 0
 - !Region
   region_id: RNA_internal
   region_type: RNA_internal
@@ -188,7 +175,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_internal
-    order: 0
   - !Region
     region_id: i5
     region_type: i5
@@ -202,7 +188,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA_internal
-    order: 1
   - !Region
     region_id: s5
     region_type: s5
@@ -214,7 +199,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_internal
-    order: 2
   - !Region
     region_id: ME1
     region_type: ME1
@@ -226,7 +210,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_internal
-    order: 3
   - !Region
     region_id: cDNA
     region_type: cDNA
@@ -238,7 +221,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_internal
-    order: 4
   - !Region
     region_id: ME2
     region_type: ME2
@@ -250,7 +232,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_internal
-    order: 5
   - !Region
     region_id: s7
     region_type: s7
@@ -262,7 +243,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_internal
-    order: 6
   - !Region
     region_id: i7
     region_type: i7
@@ -276,7 +256,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA_internal
-    order: 7
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -288,5 +267,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA_internal
-    order: 8
-  order: 0

--- a/assays/SureCell/spec.yaml
+++ b/assays/SureCell/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: read1_primer
     region_type: read1_primer
@@ -40,7 +39,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: bc1
     region_type: bc1
@@ -54,7 +52,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: spacer1
     region_type: spacer1
@@ -66,7 +63,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: bc2
     region_type: bc2
@@ -80,7 +76,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: spacer2
     region_type: spacer2
@@ -92,7 +87,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: bc3
     region_type: bc3
@@ -106,7 +100,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: spacer3
     region_type: spacer3
@@ -118,7 +111,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: umi
     region_type: umi
@@ -130,7 +122,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: spacer4
     region_type: spacer4
@@ -142,7 +133,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 9
   - !Region
     region_id: polyT
     region_type: polyT
@@ -154,7 +144,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 10
   - !Region
     region_id: cdna
     region_type: cdna
@@ -166,7 +155,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 11
   - !Region
     region_id: ME
     region_type: ME
@@ -178,7 +166,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 12
   - !Region
     region_id: s7
     region_type: s7
@@ -190,7 +177,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 13
   - !Region
     region_id: sample_index
     region_type: sample_index
@@ -204,7 +190,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 14
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -216,5 +201,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 15
-  order: 0

--- a/assays/Tang2009/spec.yaml
+++ b/assays/Tang2009/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: cDNA
     region_type: cDNA
@@ -40,7 +39,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: SOLiD_bc_adapter
     region_type: SOLiD_bc_adapter
@@ -52,7 +50,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: index
     region_type: index
@@ -66,7 +63,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: p2_adapter
     region_type: p2_adapter
@@ -78,5 +74,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
-  order: 0

--- a/assays/VASA-seq-drop/spec.yaml
+++ b/assays/VASA-seq-drop/spec.yaml
@@ -29,7 +29,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: i5
     region_type: i5
@@ -43,7 +42,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: nextera_read1
     region_type: nextera_read1
@@ -55,7 +53,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: cdna
     region_type: cdna
@@ -67,7 +64,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: polyT
     region_type: polyT
@@ -79,7 +75,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: umi
     region_type: umi
@@ -91,7 +86,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: bc2
     region_type: bc2
@@ -103,7 +97,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: nextera_read2
     region_type: nextera_read2
@@ -115,7 +108,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: bc1
     region_type: bc1
@@ -127,7 +119,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: linker
     region_type: linker
@@ -139,7 +130,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 9
   - !Region
     region_id: i7
     region_type: i7
@@ -153,7 +143,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 10
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -165,5 +154,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 11
-  order: 0

--- a/assays/VASA-seq-plate/spec.yaml
+++ b/assays/VASA-seq-plate/spec.yaml
@@ -29,7 +29,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: RA5
     region_type: RA5
@@ -41,7 +40,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: umi
     region_type: umi
@@ -53,7 +51,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: cell_barcode
     region_type: cell_barcode
@@ -65,7 +62,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: polyT
     region_type: polyT
@@ -77,7 +73,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: cdna
     region_type: cdna
@@ -89,7 +84,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: RA3
     region_type: RA3
@@ -101,7 +95,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: sample_bc
     region_type: sample_bc
@@ -115,7 +108,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -127,5 +119,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
-  order: 0

--- a/assays/inDropv2/spec.yaml
+++ b/assays/inDropv2/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: PE2
     region_type: PE2
@@ -40,7 +39,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: cdna
     region_type: cdna
@@ -52,7 +50,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: polyA
     region_type: polyA
@@ -64,7 +61,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: umi
     region_type: umi
@@ -76,7 +72,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: bc2
     region_type: bc2
@@ -90,7 +85,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: W1
     region_type: W1
@@ -102,7 +96,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: bc1
     region_type: bc1
@@ -116,7 +109,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: PE1
     region_type: PE1
@@ -128,7 +120,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: sample_index
     region_type: sample_index
@@ -142,7 +133,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 9
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -154,5 +144,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 10
-  order: 0

--- a/assays/mcSCRB-seq/spec.yaml
+++ b/assays/mcSCRB-seq/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: truseq_r1
     region_type: truseq_r1
@@ -40,7 +39,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: cell_bc
     region_type: cell_bc
@@ -54,7 +52,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: umi
     region_type: umi
@@ -66,7 +63,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: polyT
     region_type: polyT
@@ -78,7 +74,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: cdna
     region_type: cdna
@@ -90,7 +85,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: ME
     region_type: ME
@@ -102,7 +96,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: s7
     region_type: s7
@@ -114,7 +107,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: i7_index
     region_type: i7_index
@@ -128,7 +120,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -140,5 +131,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 9
-  order: 0

--- a/assays/sci-RNA-seq/spec.yaml
+++ b/assays/sci-RNA-seq/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: I2.fastq.gz
     region_type: gz
@@ -52,8 +51,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I2.fastq.gz
-      order: 0
-    order: 1
   - !Region
     region_id: truseq_read1
     region_type: truseq_read1
@@ -65,7 +62,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: R1.fastq.gz
     region_type: gz
@@ -87,7 +83,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R1.fastq.gz
-      order: 0
     - !Region
       region_id: barcode
       region_type: barcode
@@ -101,8 +96,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: R1.fastq.gz
-      order: 1
-    order: 3
   - !Region
     region_id: R2.fastq.gz
     region_type: gz
@@ -124,7 +117,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R2.fastq.gz
-      order: 0
     - !Region
       region_id: cDNA
       region_type: cDNA
@@ -136,8 +128,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: R2.fastq.gz
-      order: 1
-    order: 4
   - !Region
     region_id: nextera_read2
     region_type: nextera_read2
@@ -159,7 +149,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read2
-      order: 0
     - !Region
       region_id: s7
       region_type: s7
@@ -171,8 +160,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: nextera_read2
-      order: 1
-    order: 5
   - !Region
     region_id: I1.fastq.gz
     region_type: gz
@@ -196,8 +183,6 @@ assay_spec:
         md5: null
       regions: null
       parent_id: I1.fastq.gz
-      order: 0
-    order: 6
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -209,5 +194,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
-  order: 0

--- a/assays/sci-RNA-seq3/spec.yaml
+++ b/assays/sci-RNA-seq3/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: i5
     region_type: i5
@@ -42,7 +41,6 @@ assay_spec:
       md5: None
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: truseq_read_1_adapter
     region_type: truseq_read_1_adapter
@@ -54,7 +52,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: read_1
     region_type: read_1
@@ -78,7 +75,6 @@ assay_spec:
         md5: None
       regions: null
       parent_id: read_1
-      order: 0
     - !Region
       region_id: hairpin_adapter
       region_type: hairpin_adapter
@@ -90,7 +86,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: read_1
-      order: 1
     - !Region
       region_id: umi
       region_type: umi
@@ -102,7 +97,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: read_1
-      order: 2
     - !Region
       region_id: cell_bc
       region_type: cell_bc
@@ -116,8 +110,6 @@ assay_spec:
         md5: None
       regions: null
       parent_id: read_1
-      order: 3
-    order: 3
   - !Region
     region_id: poly_T
     region_type: poly_T
@@ -129,7 +121,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: read_2
     region_type: read_2
@@ -141,7 +132,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: i7_primer
     region_type: i7_primer
@@ -163,7 +153,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: i7_primer
-      order: 0
     - !Region
       region_id: s7
       region_type: s7
@@ -175,8 +164,6 @@ assay_spec:
       onlist: null
       regions: null
       parent_id: i7_primer
-      order: 1
-    order: 6
   - !Region
     region_id: i7
     region_type: i7
@@ -190,7 +177,6 @@ assay_spec:
       md5: None
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -202,5 +188,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
-  order: 0

--- a/assays/scifi-RNA-seq/spec.yaml
+++ b/assays/scifi-RNA-seq/spec.yaml
@@ -28,7 +28,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 0
   - !Region
     region_id: bead_bc
     region_type: bead_bc
@@ -42,7 +41,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 1
   - !Region
     region_id: s7
     region_type: s7
@@ -54,7 +52,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 2
   - !Region
     region_id: truseq_r1
     region_type: truseq_r1
@@ -66,7 +63,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 3
   - !Region
     region_id: umi
     region_type: umi
@@ -78,7 +74,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 4
   - !Region
     region_id: rt_bc
     region_type: rt_bc
@@ -92,7 +87,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 5
   - !Region
     region_id: polyT
     region_type: polyT
@@ -104,7 +98,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 6
   - !Region
     region_id: cdna
     region_type: cdna
@@ -116,7 +109,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 7
   - !Region
     region_id: ME
     region_type: ME
@@ -128,7 +120,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 8
   - !Region
     region_id: s7
     region_type: s7
@@ -140,7 +131,6 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 9
   - !Region
     region_id: i7_index
     region_type: i7_index
@@ -154,7 +144,6 @@ assay_spec:
       md5: null
     regions: null
     parent_id: RNA
-    order: 10
   - !Region
     region_id: illumina_p7
     region_type: illumina_p7
@@ -166,5 +155,3 @@ assay_spec:
     onlist: null
     regions: null
     parent_id: RNA
-    order: 11
-  order: 0

--- a/seqspec/Region.py
+++ b/seqspec/Region.py
@@ -21,7 +21,7 @@ class Region(yaml.YAMLObject):
         # join: Optional["Join"] = None,
     ) -> None:
         super().__init__()
-        self.parent = None
+        self.parent_id = None
         self.region_id = region_id
         self.region_type = region_type
         self.name = name

--- a/seqspec/Region.py
+++ b/seqspec/Region.py
@@ -42,13 +42,11 @@ class Region(yaml.YAMLObject):
             self.sequence = self.get_sequence()
 
     def set_parent_id(self, parent_id):
+        self.parent_id = parent_id
         if self.regions:
             parent_id = self.region_id
             for r in self.regions:
                 r.set_parent_id(parent_id)
-        else:
-            self.parent_id = parent_id
-        return
 
     def get_sequence(self, s: str = "") -> str:
         # take into account "order" property

--- a/seqspec/schema/seqspec.schema.json
+++ b/seqspec/schema/seqspec.schema.json
@@ -54,12 +54,6 @@
       "description": "A region of DNA",
       "type": "object",
       "properties": {
-        "order": {
-          "description": "order the region appears",
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 2048
-        },
         "region_id": {
           "description": "identifier for the region",
           "type": "string"
@@ -111,7 +105,6 @@
         }
       },
       "required": [
-        "order",
         "region_id",
         "region_type",
         "sequence_type",

--- a/seqspec/seqspec_check.py
+++ b/seqspec/seqspec_check.py
@@ -35,7 +35,7 @@ def validate_check_args(parser, args):
 
     spec = load_spec(spec_fn)
 
-    run_check(schema, spec)  # , o)
+    return run_check(schema, spec)  # , o)
 
 
 def run_check(schema, spec):
@@ -45,3 +45,5 @@ def run_check(schema, spec):
         print(
             f"[error {idx}] {error.message} in spec[{']['.join(repr(index) for index in error.path)}]"
         )
+
+    return idx

--- a/seqspec/seqspec_check.py
+++ b/seqspec/seqspec_check.py
@@ -42,7 +42,7 @@ def run_check(schema, spec):
 
     v = Draft4Validator(schema)
     idx = 0
-    for idx, error in enumerate(v.iter_errors(spec), 1):
+    for idx, error in enumerate(v.iter_errors(spec.to_dict()), 1):
         print(
             f"[error {idx}] {error.message} in spec[{']['.join(repr(index) for index in error.path)}]"
         )

--- a/seqspec/seqspec_check.py
+++ b/seqspec/seqspec_check.py
@@ -41,6 +41,7 @@ def validate_check_args(parser, args):
 def run_check(schema, spec):
 
     v = Draft4Validator(schema)
+    idx = 0
     for idx, error in enumerate(v.iter_errors(spec), 1):
         print(
             f"[error {idx}] {error.message} in spec[{']['.join(repr(index) for index in error.path)}]"

--- a/seqspec/utils.py
+++ b/seqspec/utils.py
@@ -1,10 +1,15 @@
+import io
 from seqspec.Assay import Assay
 import yaml
 
 
 def load_spec(spec_fn: str):
     with open(spec_fn, "r") as stream:
-        data: Assay = yaml.load(stream, Loader=yaml.Loader)
+        return load_spec_stream(stream)
+
+
+def load_spec_stream(spec_stream: io.IOBase):
+    data: Assay = yaml.load(spec_stream, Loader=yaml.Loader)
     # set the parent id in the Assay object upon loading it
     for r in data.assay_spec:
         r.set_parent_id(None)

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,13 @@ exclude = .git,.github,__pycache__,build,dist
 statistics = True
 max-line-length = 88
 extend-ignore = E203,E501
+
+[tox:tox]
+env_list=py{37,38,39,310,311}
+skip_missing_interpreters=True
+
+[testenv]
+commands=pytest --cov=seqspec {posargs:tests}
+deps =
+    pytest
+    pytest-cov

--- a/tests/test_assay.py
+++ b/tests/test_assay.py
@@ -1,0 +1,48 @@
+import json
+from unittest import TestCase
+from seqspec.Region import Region
+from seqspec.Assay import Assay
+
+from .test_region import (
+    region_rna_joined_dict,
+    region_rna_umi_dict,
+    region_rna_linker_dict,
+)
+
+
+def assay_dict(regions=[]):
+    return {
+        "name": "A machine-readable specification for genomics assays",
+        "doi": "https://doi.org/10.1101/2023.03.17.533215",
+        "publication_date": "20230317",
+        "description": "description",
+        "modalities": ["RNA", "cDNA"],
+        "lib_struct": "lib_struct",
+        "assay_spec": regions,
+    }
+
+
+class TestAssay(TestCase):
+    def test_minimal(self):
+        expected = assay_dict()
+
+        a = Assay(**assay_dict())
+        self.assertEqual(a.to_dict(), expected)
+
+        self.assertEqual(a.to_JSON(), json.dumps(expected, sort_keys=False, indent=4))
+
+    def test_assay_with_regions(self):
+        r_umi_dict = region_rna_umi_dict("region-2")
+        r_umi = Region(**r_umi_dict)
+        r_linker_dict = region_rna_linker_dict("region-3")
+        r_linker = Region(**r_linker_dict)
+        r_expected_dict = region_rna_joined_dict("region-1", [r_umi, r_linker])
+        r_expected = Region(**r_expected_dict)
+
+        expected = assay_dict(regions=[r_expected])
+
+        a = Assay(**expected)
+
+        self.assertEqual(a.get_modality("RNA"), r_expected)
+
+        self.assertRaises(IndexError, a.get_modality, "cDNA")

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -1,0 +1,197 @@
+from unittest import TestCase
+
+from seqspec.Region import Region, Onlist
+
+
+def region_rna_joined_dict(region_id, regions=[]):
+    expected = {
+        "region_id": region_id,
+        "region_type": "joined",
+        "name": f"{region_id}-joined",
+        "sequence_type": "RNA",
+        "regions": regions,
+    }
+    return expected
+
+
+def region_rna_umi_dict(region_id, regions=[]):
+    expected = {
+        "region_id": region_id,
+        "region_type": "umi",
+        "name": f"{region_id}-umi",
+        "sequence_type": "RNA",
+        "sequence": "NNNNNN",
+        "regions": regions,
+    }
+    return expected
+
+
+def region_rna_linker_dict(region_id, regions=[]):
+    expected = {
+        "region_id": region_id,
+        "region_type": "linker",
+        "name": f"{region_id}-linker",
+        "sequence_type": "RNA",
+        "sequence": "CATTGG",
+        "regions": regions,
+    }
+    return expected
+
+
+class TestOnlist(TestCase):
+    def test_simple_onlist(self):
+        name = "barcodes.txt"
+        md5sum = "d41d8cd98f00b204e9800998ecf8427e"
+
+        permit = Onlist(name, md5sum)
+
+        self.assertEqual(
+            permit.to_dict(),
+            {"filename": name, "md5": md5sum},
+        )
+
+
+class TestRegion(TestCase):
+    def test_minimal_region(self):
+        expected = region_rna_joined_dict("region-1")
+        r = Region(**expected)
+        self.assertEqual(r.region_id, expected["region_id"])
+        self.assertEqual(r.region_type, expected["region_type"])
+        self.assertEqual(r.name, expected["name"])
+        self.assertEqual(r.sequence_type, expected["sequence_type"])
+        self.assertEqual(r.order, 0)
+        self.assertEqual(r.sequence, "")
+        self.assertEqual(r.min_len, 0)
+        self.assertEqual(r.max_len, 1024)
+        self.assertIs(r.onlist, None)
+        self.assertEqual(r.regions, [])
+
+        self.assertEqual(r.get_region_by_id(expected["region_id"]), [r])
+        self.assertEqual(r.get_region_by_type(expected["region_type"]), [r])
+        self.assertEqual(r.get_leaves(), [r])
+        self.assertEqual(r.get_leaf_region_types(), set([expected["region_type"]]))
+
+    def test_unique_subregions(self):
+        r_umi_dict = region_rna_umi_dict("region-2")
+        r_umi = Region(**r_umi_dict)
+        r_linker_dict = region_rna_linker_dict("region-3")
+        r_linker = Region(**r_linker_dict)
+        r_expected_dict = region_rna_joined_dict("region-1", [r_umi, r_linker])
+        r_expected_dict["sequence"] = r_umi_dict["sequence"] + r_linker_dict["sequence"]
+        r_expected = Region(**r_expected_dict)
+
+        self.assertEqual(r_umi.get_sequence(), r_umi_dict["sequence"])
+        self.assertEqual(r_linker.get_sequence(), r_linker_dict["sequence"])
+
+        self.assertEqual(r_expected.regions[0].get_sequence(), r_umi_dict["sequence"])
+        self.assertEqual(
+            r_expected.regions[1].get_sequence(), r_linker_dict["sequence"]
+        )
+        self.assertEqual(
+            r_expected.get_sequence(),
+            r_umi_dict["sequence"] + r_linker_dict["sequence"],
+        )
+
+        self.assertEqual(r_expected.get_region_by_id(r_umi_dict["region_id"]), [r_umi])
+        self.assertEqual(
+            r_expected.get_region_by_type(r_umi_dict["region_type"]), [r_umi]
+        )
+        self.assertEqual(
+            r_expected.get_region_by_id(r_linker_dict["region_id"]), [r_linker]
+        )
+        self.assertEqual(
+            r_expected.get_region_by_type(r_linker_dict["region_type"]), [r_linker]
+        )
+        self.assertEqual(r_expected.get_leaves(), [r_umi, r_linker])
+        self.assertEqual(
+            r_expected.get_leaf_region_types(),
+            set([r_umi_dict["region_type"], r_linker_dict["region_type"]]),
+        )
+
+        # 0 & 1024 are the default min & max
+        self.assertEqual(r_expected.min_len, 0)
+        self.assertEqual(r_expected.max_len, 1024 * len(r_expected.regions))
+
+        # update_attr just sums up all the mins & maxes
+        r_expected.update_attr()
+        self.assertEqual(r_expected.min_len, 0)
+        self.assertEqual(r_expected.max_len, 1024 * len(r_expected.get_leaves()))
+
+    def test_retrieving_subregions_with_same_types(self):
+        r2_dict = region_rna_umi_dict("region-2")
+        r2 = Region(**r2_dict)
+        r3_dict = region_rna_linker_dict("region-3")
+        r3 = Region(**r3_dict)
+        r4_dict = region_rna_umi_dict("region-4")
+        r4 = Region(**r4_dict)
+        r1_dict = region_rna_joined_dict("region-1", [r2, r3, r4])
+        r1 = Region(**r1_dict)
+
+        self.assertEqual(r1.get_region_by_type(r2_dict["region_type"]), [r2, r4])
+
+    def test_set_parent_id(self):
+        r2_dict = region_rna_umi_dict("region-2")
+        r2 = Region(**r2_dict)
+        r3_dict = region_rna_linker_dict("region-3")
+        r3 = Region(**r3_dict)
+
+        r5_dict = region_rna_umi_dict("region-5")
+        r5 = Region(**r5_dict)
+        r6_dict = region_rna_linker_dict("region-5")
+        r6 = Region(**r6_dict)
+        r4_dict = region_rna_joined_dict("region-4", [r5, r6])
+        r4 = Region(**r4_dict)
+
+        r1_regions = [r2, r3, r4]
+        r1_dict = region_rna_joined_dict("region-1", r1_regions)
+        r1 = Region(**r1_dict)
+
+        self.assertIs(r1.parent_id, None)
+        self.assertEqual(len(r1.regions), len(r1_regions))
+        for node in r1.regions:
+            self.assertIs(node.parent_id, None)
+
+        r1.set_parent_id(r1.region_id)
+        self.assertIs(r1.parent_id, r1.region_id)
+        for node in r1.regions:
+            self.assertIs(node.parent_id, r1.region_id)
+
+    def test_onlists(self):
+        region_name = "region-1"
+        region_type = "linker"
+        sequence_type = "stuff"
+        sequence = "AACGTGAT"
+
+        list_name = "barcodes.txt"
+        list_md5sum = "d41d8cd98f00b204e9800998ecf8427e"
+
+        permited = Onlist(list_name, list_md5sum)
+
+        r = Region(
+            region_name,
+            region_type,
+            region_name,
+            sequence_type,
+            sequence=sequence,
+            onlist=permited,
+        )
+
+        expected = {
+            "region_id": region_name,
+            "region_type": region_type,
+            "name": region_name,
+            "sequence_type": sequence_type,
+            "onlist": {"filename": list_name, "md5": list_md5sum},
+            "sequence": sequence,
+            "min_len": 0,
+            "max_len": 1024,
+            "regions": [],
+        }
+
+        self.assertEqual(r.to_dict(), expected)
+
+        # should to_dict() and repr() look the same?
+        # the code currently returns region: [] for to_dict
+        # and region: None for repr()
+        expected["regions"] = None
+        self.assertEqual(repr(r), repr(expected))

--- a/tests/test_seqspec_check.py
+++ b/tests/test_seqspec_check.py
@@ -1,0 +1,48 @@
+from argparse import ArgumentParser
+import os
+from pathlib import Path
+from unittest import TestCase, skipUnless
+
+from seqspec.seqspec_check import (
+    setup_check_args,
+    validate_check_args,
+)
+
+
+test_dir = Path(__file__).parent
+default_assay_dir = test_dir / '..' / 'assays'
+assay_dir = os.environ.get("SEQSPEC_ASSAY_DIR", default_assay_dir)
+
+
+def create_stub_check_parser():
+    parser = ArgumentParser()
+    subparser = parser.add_subparsers(
+        dest="command",
+        metavar="<CMD>",
+    )
+    subparser = setup_check_args(subparser)
+    return parser
+
+
+class TestSeqspecCheck(TestCase):
+    def test_check_args(self):
+        parser = create_stub_check_parser()
+
+        output_name = "output"
+        spec_name = "spec.yaml"
+        cmdline = ["check", "-o", output_name, spec_name]
+        args = parser.parse_args(cmdline)
+
+        self.assertEqual(args.o, output_name)
+        self.assertEqual(args.yaml, spec_name)
+
+    @skipUnless(assay_dir.is_dir(), "Couldn't find assays directory")
+    def test_validate_check_args(self):
+        parser = create_stub_check_parser()
+
+        smart_seq3 = assay_dir / "Smart-seq3" / "spec.yaml"
+        cmdline = ["check", str(smart_seq3)]
+        args = parser.parse_args(cmdline)
+
+        errors = validate_check_args(None, args)
+        self.assertEqual(errors, 0)

--- a/tests/test_seqspec_check.py
+++ b/tests/test_seqspec_check.py
@@ -40,8 +40,8 @@ class TestSeqspecCheck(TestCase):
     def test_validate_check_args(self):
         parser = create_stub_check_parser()
 
-        smart_seq3 = assay_dir / "Smart-seq3" / "spec.yaml"
-        cmdline = ["check", str(smart_seq3)]
+        spec = assay_dir / "Quartz-seq" / "spec.yaml"
+        cmdline = ["check", str(spec)]
         args = parser.parse_args(cmdline)
 
         errors = validate_check_args(None, args)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,136 @@
+from io import StringIO
+import os
+from unittest import TestCase
+
+from seqspec.Region import Region
+from seqspec.utils import (
+    load_spec_stream, get_cuts, write_read
+)
+
+from .test_region import (
+    region_rna_joined_dict,
+    region_rna_umi_dict,
+    region_rna_linker_dict,
+)
+
+example_spec = """!Assay
+name: my assay
+doi: https://doi.org/10.1038/nmeth.1315
+publication_date: 06 April 2009
+description: first method to sequence the whole transcriptome (mRNA) of a single cell
+modalities:
+- RNA
+lib_struct: https://teichlab.github.io/scg_lib_structs/methods_html/tang2009.html
+assay_spec:
+- !Region
+  region_id: RNA
+  region_type: RNA
+  name: RNA
+  sequence_type: joined
+  sequence: CCACTACGCCTCCGCTTTCCTCTCTATGGGCAGTCGGTGATXCGCCTTGGCCGTACAGCAGNNNNNNAGAGAATGAGGAACCCGGGGCAG
+  min_len: 90
+  max_len: 187
+  onlist: null
+  regions:
+  - !Region
+    region_id: SOLiD_P1_adaptor
+    region_type: SOLiD_P1_adaptor
+    name: SOLiD_P1_adaptor
+    sequence_type: fixed
+    sequence: CCACTACGCCTCCGCTTTCCTCTCTATGGGCAGTCGGTGAT
+    min_len: 41
+    max_len: 41
+    onlist: null
+    regions: null
+    parent_id: RNA
+    order: 0
+  - !Region
+    region_id: cDNA
+    region_type: cDNA
+    name: cDNA
+    sequence_type: random
+    sequence: X
+    min_len: 1
+    max_len: 98
+    onlist: null
+    regions: null
+    parent_id: RNA
+    order: 1
+  - !Region
+    region_id: SOLiD_bc_adapter
+    region_type: SOLiD_bc_adapter
+    name: SOLiD_bc_adapter
+    sequence_type: fixed
+    sequence: CGCCTTGGCCGTACAGCAG
+    min_len: 19
+    max_len: 19
+    onlist: null
+    regions: null
+    parent_id: RNA
+    order: 2
+  - !Region
+    region_id: index
+    region_type: index
+    name: index
+    sequence_type: onlist
+    sequence: NNNNNN
+    min_len: 6
+    max_len: 6
+    onlist: !Onlist
+      filename: index_onlist.txt
+      md5: null
+    regions: null
+    parent_id: RNA
+    order: 3
+  - !Region
+    region_id: p2_adapter
+    region_type: p2_adapter
+    name: p2_adapter
+    sequence_type: fixed
+    sequence: AGAGAATGAGGAACCCGGGGCAG
+    min_len: 23
+    max_len: 23
+    onlist: null
+    regions: null
+    parent_id: RNA
+    order: 4
+  order: 0
+"""
+
+
+class TestUtils(TestCase):
+    def test_load_spec_stream(self):
+        with StringIO(example_spec) as instream:
+            spec = load_spec_stream(instream)
+        self.assertEqual(spec.name, "my assay")
+        head = spec.get_modality("RNA")
+        self.assertEqual(len(head.regions), 5)
+
+    def test_get_cuts(self):
+        r_umi_dict = region_rna_umi_dict("region-2")
+        r_umi = Region(**r_umi_dict)
+        r_linker_dict = region_rna_linker_dict("region-3")
+        r_linker = Region(**r_linker_dict)
+        r_expected_dict = region_rna_joined_dict("region-1", [r_umi, r_linker])
+        r_expected_dict["sequence"] = r_umi_dict["sequence"] + r_linker_dict["sequence"]
+        r_expected = Region(**r_expected_dict)
+
+        r_umi_min, r_umi_max = r_umi.get_len()
+        r_linker_min, r_linker_max = r_linker.get_len()
+        r_linker_min += r_umi_max
+        r_linker_max += r_linker_max
+        cuts = get_cuts(r_expected.regions)
+        self.assertEqual(cuts, [(r_umi_min, r_umi_max), (r_linker_min, r_linker_max)])
+
+    def test_write_header(self):
+        stream = StringIO()
+        header = "@string"
+        sequence = "CANNTG"
+        quality = "IIIIII"
+        write_read(header, sequence, quality, stream)
+
+        text = stream.getvalue().split(os.linesep)
+        self.assertEqual(text[0], f"{header}")
+        self.assertEqual(text[1], sequence)
+        self.assertEqual(text[2], "+")
+        self.assertEqual(text[3], quality)


### PR DESCRIPTION
The first commit adds tests for the Assay & Region objects.

And testing the setters showed that there was disagreement over if the parent reference was named parent or parent_id.

So the second commit renames parent to parent_id.

The set_parent_id test will still fail with this pull request though because as it's currently implemented if you have a nested tree the sub parents wont have their parent_id set.

But I'm going to make a different pull request for that change, since the right answer is more debatable.