### PR TITLE
Jsonschema requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-cov
+tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyyaml==6.0
+jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyyaml==6.0
+pyyaml>=6.0
 jsonschema


### PR DESCRIPTION
Here's the changes to the requirements files.

I did loosen the requirements for pyyaml, since there may be future versions, and also I tested on an older debian system and pyyaml 5.3 does work.

There's also the possibility of encoding the requirements in the setup.cfg file with something like this, though I don't remember if there's also a tests_requires.

```ini
+
+[options]
+zip_safe = False
+packages = find:
+install_requires = 
+    pyyaml >= 5.3
+    jsonschema
+    

```