### PR TITLE
Make to_dict and to_JSON generate dictionaries with keys in the same order

### DIFF
--- a/seqspec/Assay.py
+++ b/seqspec/Assay.py
@@ -22,9 +22,9 @@ class Assay(yaml.YAMLObject):
         seqspec_version: str = __version__,
     ) -> None:
         super().__init__()
+        self.seqspec_version = seqspec_version
         self.assay = assay
         self.sequencer = sequencer
-        self.seqspec_version = seqspec_version
         self.name = name
         self.doi = doi
         self.publication_date = publication_date

--- a/tests/test_assay.py
+++ b/tests/test_assay.py
@@ -12,6 +12,7 @@ from .test_region import (
 
 def assay_dict(regions=[]):
     return {
+        "seqspec_version": "0.0.0",
         "assay": "My assay",
         "sequencer": "My sequencing machine",
         "name": "A machine-readable specification for genomics assays",


### PR DESCRIPTION
to_dict has a hard coded attribute order used when generating a dictionary to return, which is different from the order generated by directly accessing the class' __dict__ attribute.

It might be easier to be consistent to have to_JSON call to_dict so they both generate the same order.