### PR TITLE
expand sequence in schema.json for IUPAC nucleotides

### DIFF
--- a/seqspec/schema/seqspec.schema.json
+++ b/seqspec/schema/seqspec.schema.json
@@ -119,7 +119,7 @@
         "sequence": {
           "description": "The sequence",
           "type": "string",
-          "pattern": "^[ACGTNX]+$"
+          "pattern": "^[ACGTRYMKSWHBVDNX]+$"
         },
         "min_len": {
           "description": "The minimum length of the sequence",


### PR DESCRIPTION
Expands `seqspec.schema.json` to incorporate IUPAC codes for nucleotide bases beyond ACGTNX for precision.

Example case: A sequencing library containing an artifactual region of either a cytosine or thymine. Can be represented more precisely by IUPAC code "Y" (pYrimidine) instead of "N" (aNy base).

Ref: genome.ucsc.edu/goldenPath/help/iupac.html