### PR TITLE
add requests to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyyaml>=6.0
 jsonschema
 newick
+requests


### PR DESCRIPTION
minor push to add `requests` package to `requirements.txt`. tested on few systems that it resolves issue #20 by installing requests-2.31.0 (as of today) during pip-based install of the seqspec repo.